### PR TITLE
Remove extraneous -e flag from docker run command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Provides wildcard domain name resolution for local development.
 ### Wildcard domain name resolution
 
 ```bash
-$ docker run --name dns -d -e DNS_DOMAIN=docksal -e DNS_IP=192.168.64.100 -e docksal/dns
+$ docker run --name dns -d -e DNS_DOMAIN=docksal -e DNS_IP=192.168.64.100 docksal/dns
 
 $ nslookup something.docksal 192.168.64.100
 Server:		192.168.64.100


### PR DESCRIPTION
The example command under the "Wildcard domain name resolution" heading gives an error.

There are three uses of the `-e` option, but the last one is not needed.  It's being interpreted as `-e docksal/dns` and this gives an error saying that the required image name is missing.

This patch removes the last instance of `-e`.