### PR TITLE
Revert "Added *.local resolution to 127.0.0.1"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,15 +12,6 @@ if [ "$1" = 'supervisord' ]; then
 	# Reverse resolution of $DNS_IP to ${DNS_DOMAIN}
 	echo $DNS_IP | awk -v dzone=${DNS_DOMAIN} -F . '{print "ptr-record="$4"."$3"."$2"."$1".in-addr.arpa,"dzone}' | tee -a $domain_conf
 
-	# Resolve *.local to 127.0.0.1 unless config file already exists (e.g. generated above)
-	local_conf="/etc/dnsmasq.d/local.conf"
-	if [ ! -f $local_conf ]; then
-        echo "Generating configuration in $local_conf"
-        touch $local_conf
-        echo "address=/local/127.0.0.1" | tee -a $local_conf
-        echo "ptr-record=1.0.0.127.in-addr.arpa,local" | tee -a $local_conf
-    fi
-
 	# Turn query loggin on
 	if [ "$LOG_QUERIES" = true ]; then
 		echo -e '\nlog-queries' >> /etc/dnsmasq.conf


### PR DESCRIPTION
This removes the default resolution of `.local` domains as added in commit 42b64a71c3850dc019b806120ab716fdbb1a8356.

Fixes #2.