### PR TITLE
Fix DNS resolution order by setting strict-order

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN curl -sSL https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GE
 	tar -C /usr/local/bin -xvzf $DOCKER_GEN_TARFILE && \
 	rm $DOCKER_GEN_TARFILE
 
+# Set strict-order
+RUN sed -i '/strict-order/s/^#//g' /etc/dnsmasq.conf
+
 # dnsmasq config dir
 RUN mkdir -p /etc/dnsmasq.d && \
 	echo -e '\nconf-dir=/etc/dnsmasq.d,.tmpl' >> /etc/dnsmasq.conf


### PR DESCRIPTION
Dnsmasq resolves the nameservers in /etc/resolv.conf in parallel and responds
with the first DNS answer it gets. Since we want to prioritize the first
nameserver we set on the container using --dns="...", we enable the
strict-order option in dnsmasq.

Fixes #5.